### PR TITLE
Unified output

### DIFF
--- a/bin/checkout
+++ b/bin/checkout
@@ -43,10 +43,10 @@ do
     [[ "$DO_FETCH" -eq "1" ]] && git fetch
 
     if [[ ! -z "$(git branch -r | grep "$BRANCH")" ]]; then 
-      info "Checking out '$BRANCH' of $BASENAME..."
+      info "[$BASENAME] Checking out '$BRANCH'..."
       git checkout ${ARGS[@]} $BRANCH
     else
-      warn "'$BRANCH' not a valid refspec in $BASENAME, checking out master..."
+      warn "[$BASENAME] Branch '$BRANCH' not found, checking out master..."
       git checkout ${ARGS[@]} master
     fi
 

--- a/bin/clean-branches
+++ b/bin/clean-branches
@@ -24,7 +24,7 @@ do
 
     cd "$REPODIR" 
     BASENAME=$(basename $(pwd))
-    info "Cleaning local $BASENAME branches..."
+    info "[$BASENAME] Cleaning local branches..."
     echo "Fetching all remotes"
     git fetch  > /dev/null && git remote prune origin > /dev/null
     

--- a/bin/diff
+++ b/bin/diff
@@ -24,7 +24,7 @@ do
 
     cd "$REPODIR"
     BASENAME=$(basename $(pwd))
-    info "Getting diff $BASENAME..."
+    info "[$BASENAME] Getting diffs..."
     git diff ${ARGS[@]}
     cd "$CURR_DIR"
   )

--- a/bin/fetch
+++ b/bin/fetch
@@ -24,7 +24,7 @@ do
 
     cd "$REPODIR" 
     BASENAME=$(basename $(pwd))
-    echo "Fetching $BASENAME..."
+    info "[$BASENAME] Fetching..."
     git fetch ${ARGS[@]}
     cd "$CURR_DIR"
   )

--- a/bin/info
+++ b/bin/info
@@ -24,7 +24,7 @@ do
 
     cd "$REPODIR"
     BASENAME=$(basename $(pwd))
-    info "Getting imfo $BASENAME..."
+    info "[$BASENAME] Getting info..."
     echo "HEAD currently @ $(git rev-parse --abbrev-ref HEAD ${ARGS[@]})"
     cd "$CURR_DIR"
   )

--- a/bin/prune
+++ b/bin/prune
@@ -24,7 +24,7 @@ do
 
     cd "$REPODIR" 
     BASENAME=$(basename $(pwd))
-    echo "Updating $BASENAME..."
+    info "[$BASENAME] Pruning remote branches..."
     git remote prune origin ${ARGS[@]}
     cd "$CURR_DIR"
   )

--- a/bin/pull
+++ b/bin/pull
@@ -24,7 +24,7 @@ do
 
     cd "$REPODIR"
     BASENAME=$(basename $(pwd))
-    echo "Pulling $BASENAME..."
+    info "[$BASENAME] Pulling..."
     git pull ${ARGS[@]}
     cd "$CURR_DIR"
   )

--- a/bin/reset
+++ b/bin/reset
@@ -26,7 +26,7 @@ do
 
     cd "$REPODIR"
     BASENAME=$(basename $(pwd))
-    info "Resetting $BASENAME..."
+    info "[$BASENAME] Resetting..."
     git reset ${ARGS[@]} 
     cd "$CURR_DIR"
   )

--- a/bin/status
+++ b/bin/status
@@ -24,7 +24,7 @@ do
 
     cd "$REPODIR"
     BASENAME=$(basename $(pwd))
-    info "Getting status $BASENAME..."
+    info "[$BASENAME] Getting status..."
     git status ${ARGS[@]}
     cd "$CURR_DIR"
   )


### PR DESCRIPTION
- Use logging consistently.
- Start log messages with `[<reponame>]`.
