### PR TITLE
Add `--force-delete`  for clean-branches

### DIFF
--- a/autocompletion/gittools.completion
+++ b/autocompletion/gittools.completion
@@ -98,6 +98,10 @@ _gpull() {
     __DEFAULT "--help --repository --branch --preserve-merges --rebase"
 }
 
+_gcleanbranches() {
+    __DEFAULT "--help --repository --branch --force-delete"
+}
+
 function list_directories {
     k=0
     for WORD in $( compgen -f "${cur//--repository=}" ); do # loop trough the possible completions
@@ -139,7 +143,7 @@ function get_repos {
 } 
 
 complete -o nospace -F _gcheckout gcheckout
-complete -o nospace -F _gdefault gclean-branches
+complete -o nospace -F _gcleanbranches gclean-branches
 complete -o nospace -F _gdefault gdiff
 complete -o nospace -F _gdefault gfetch
 complete -o nospace -F _gdefault ginfo

--- a/bin/clean-branches
+++ b/bin/clean-branches
@@ -8,6 +8,9 @@ function usage {
   echo "     -r <repofile|repodir>, --repository=<repofile|repodir> :"
   echo "       A file with all repos relative to script"
   echo "       defaults to \$DEVTOOLDIR/.reporc"
+  echo ""
+  echo "     --force-delete, -f:"
+  echo "       Force delete branches"
 
   exit 1
 }
@@ -15,6 +18,9 @@ function usage {
 BASEPATH=$(dirname "$0")
 source "$BASEPATH/.functions"
 
+
+get_additional_arg "--force-delete" "FORCE"
+get_additional_arg "-f" "FORCE"
 loose_set_repo "${ARGS[@]}"
 
 for REPO in "${REPOS[@]}"
@@ -45,7 +51,10 @@ do
         if [[ -n $(echo "$LOCAL" | grep "^\* ") ]]; then
           warn " Cannot delete the branch '${LOCAL//* /}' which you are currently on." 
         else
-          git branch -d "$LOCAL"
+          if [[ "$FORCE" -eq "1" ]]; then 
+            FORCE_DELETE="--force"
+          fi
+          git branch --delete $FORCE_DELETE "$LOCAL"
         fi
       fi
     done < <(git branch);


### PR DESCRIPTION
Pass parameter `-f` or `--force-delete` to use `git branch -D` instead of `git branch -d` with `clean-branches` command.
